### PR TITLE
Prevent the use of an uninitialised variable in msg_loop

### DIFF
--- a/src/msg_passing.c
+++ b/src/msg_passing.c
@@ -84,7 +84,7 @@ void * msg_loop(void * arg)
     struct timespec ts = {0, 0};
     ts.tv_sec = time(NULL) + 60*60; //1 hour
     while(1) { //iterate over all elements in queue
-      struct msg *msg;
+      struct msg *msg = NULL;
       time_t now = time(NULL);
       int orig_type;
 


### PR DESCRIPTION
Resolves the following Valgrind error:

```
Conditional jump or move depends on uninitialised value(s)
    at 0x468F22: msg_loop(void*) (msg_passing.c:103)
    by 0x4E3CDC4: start_thread (pthread_create.c:308)
    by 0x5F8521C: clone (clone.S:113)
```
